### PR TITLE
Release v0.0.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## v0.0.17 - 2026-01-22
+
+- d2cf9d6 docs: Add detailed tables for provider, network, provision, and trigger options in README files
+- 3feb87f fix(provision): set default `privileged` option to false in provision settings
+
 ## v0.0.16 - 2026-01-22
 
 - feat(bindfs): Add setup and configuration details for vagrant-bindfs plugin

--- a/src/main/ruby/lib/radp_vagrant/version.rb
+++ b/src/main/ruby/lib/radp_vagrant/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RadpVagrant
-  VERSION = 'v0.0.16'
+  VERSION = 'v0.0.17'
 end


### PR DESCRIPTION
Release prep for v0.0.17. When merged, create-version-tag will run automatically.