### PR TITLE
Release v0.0.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v0.0.23 - 2026-01-23
+
+- e076122 docs: update README to include new SSH host trust and chrony time sync provisions
+- 288a2b8 feat(provision): add SSH host trust and chrony time sync predefined provisions
+- b54cac9 feat(provision): restructure NFS mount definition to enhance env variable descriptions
+- 850a1b2 feat(provision): update user provision structure and enhance provision descriptions
+- 7c67c8d feat(provision): refactor provision script handling and enhance default merging logic
 ## v0.0.22 - 2026-01-23
 
 - Support predefined builitin provisions and user predefined provisions

--- a/src/main/ruby/lib/radp_vagrant/version.rb
+++ b/src/main/ruby/lib/radp_vagrant/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RadpVagrant
-  VERSION = 'v0.0.22'
+  VERSION = 'v0.0.23'
 end


### PR DESCRIPTION
Release prep for v0.0.23. When merged, create-version-tag will run automatically.