### PR TITLE
Release v0.0.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.0.25 - 2026-01-23
+
+- 1c37753 fix(radp-vf): resolve relative output path to absolute before directory change
+- 8ff4fb4 chore(path_resolver): add missing `pathname` require for path operations
 ## v0.0.24 - 2026-01-23
 
 - 17ae299 docs: update README to document new SSH cluster trust provision

--- a/src/main/ruby/lib/radp_vagrant/version.rb
+++ b/src/main/ruby/lib/radp_vagrant/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RadpVagrant
-  VERSION = 'v0.0.24'
+  VERSION = 'v0.0.25'
 end


### PR DESCRIPTION
Release prep for v0.0.25. When merged, create-version-tag will run automatically.