### PR TITLE
Release v0.0.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.0.26 - 2026-01-23
+
+- 26ddf2c fix(provision): ensure provisioner names support `--provision-with` compatibility for shell and file types
+- 6b76582 fix(provision): improve custom NTP server configuration and chrony service detection
 ## v0.0.25 - 2026-01-23
 
 - 1c37753 fix(radp-vf): resolve relative output path to absolute before directory change

--- a/src/main/ruby/lib/radp_vagrant/version.rb
+++ b/src/main/ruby/lib/radp_vagrant/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RadpVagrant
-  VERSION = 'v0.0.25'
+  VERSION = 'v0.0.26'
 end


### PR DESCRIPTION
Release prep for v0.0.26. When merged, create-version-tag will run automatically.