### PR TITLE
Release v0.0.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.0.27 - 2026-01-23
+
+- 90ef974 docs(triggers): document builtin triggers system and usage details
+- 6ca7564 feat(triggers): add builtin trigger to disable firewalld, SELinux, and swap
+- c4ac685 feat(triggers): add support for builtin trigger registry and resolution
+- b74c056 refactor(generator): remove unused `name` variable from provision generation method
 ## v0.0.26 - 2026-01-23
 
 - 26ddf2c fix(provision): ensure provisioner names support `--provision-with` compatibility for shell and file types

--- a/src/main/ruby/lib/radp_vagrant/version.rb
+++ b/src/main/ruby/lib/radp_vagrant/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RadpVagrant
-  VERSION = 'v0.0.26'
+  VERSION = 'v0.0.27'
 end


### PR DESCRIPTION
Release prep for v0.0.27. When merged, create-version-tag will run automatically.