### PR TITLE
Release v0.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v0.1.8 - 2026-01-25
+
+- 69e4ecf feat: add support for installing and copying project templates
 ## v0.1.7 - 2026-01-25
 
 - 873d6be docs: reorganize and update README with template and usage enhancements

--- a/src/main/ruby/lib/radp_vagrant/version.rb
+++ b/src/main/ruby/lib/radp_vagrant/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RadpVagrant
-  VERSION = 'v0.1.7'
+  VERSION = 'v0.1.8'
 end


### PR DESCRIPTION
Release prep for v0.1.8. When merged, create-version-tag will run automatically.