### PR TITLE
Release v0.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.1.9 - 2026-01-26
+
+- 12ef36b feat: Add rebuild zsh completion cache instructions
+- 5bcec51 feat: Add completion scripts
+- 03bd468 feat: Add template subcmd
 ## v0.1.8 - 2026-01-25
 
 - 69e4ecf feat: add support for installing and copying project templates

--- a/src/main/ruby/lib/radp_vagrant/version.rb
+++ b/src/main/ruby/lib/radp_vagrant/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RadpVagrant
-  VERSION = 'v0.1.8'
+  VERSION = 'v0.1.9'
 end


### PR DESCRIPTION
Release prep for v0.1.9. When merged, create-version-tag will run automatically.