### PR TITLE
Release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.2.0 - 2026-01-27
+
+- f0b7bee chore: update CLAUDE.md
+- aec0d70 feat(cli): Update shell completion
+- 33fccd5 feat(cli): consistence cli args
 ## v0.1.11 - 2026-01-27
 
 - 44a6fed chore: Optimize install.sh

--- a/src/main/ruby/lib/radp_vagrant/version.rb
+++ b/src/main/ruby/lib/radp_vagrant/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RadpVagrant
-  VERSION = 'v0.1.11'
+  VERSION = 'v0.2.0'
 end


### PR DESCRIPTION
Release prep for v0.2.0. When merged, create-version-tag will run automatically.