### PR TITLE
Release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## v0.2.1 - 2026-01-28
 
+- bb55267 feat(provision): Add builtin provision gpg-import
+- f0d3583 feat(provision): Add builtin provision gpg-import
+- 3519472 chore: fix install
+- 14fc729 chore: add post-install message
+- f05c06e docs: update installation
+- 46170ad chore: update install and uninstall
+- 391477f chore: update install and uninstall
+## v0.2.1 - 2026-01-28
+
 - feat(provision): add builtin GPG key import provision (radp:crypto/gpg-import)
   - Support public key import from content, file, or keyserver
   - Support secret key import with passphrase

--- a/src/main/ruby/lib/radp_vagrant/version.rb
+++ b/src/main/ruby/lib/radp_vagrant/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RadpVagrant
-  VERSION = 'v0.2.0'
+  VERSION = 'v0.2.1'
 end


### PR DESCRIPTION
Release prep for v0.2.1. When merged, create-version-tag will run automatically.