### PR TITLE
Release v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v0.2.2 - 2026-01-28
+
+- d263971 feat(provision): optimize builtin provision gpg-import
 ## v0.2.1 - 2026-01-28
 
 - bb55267 feat(provision): Add builtin provision gpg-import

--- a/src/main/ruby/lib/radp_vagrant/version.rb
+++ b/src/main/ruby/lib/radp_vagrant/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RadpVagrant
-  VERSION = 'v0.2.1'
+  VERSION = 'v0.2.2'
 end


### PR DESCRIPTION
Release prep for v0.2.2. When merged, create-version-tag will run automatically.