### PR TITLE
Release v0.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v0.2.6 - 2026-01-28
+
+- 399b44b fix: fix banner version
 ## Unreleased
 
 ### feat

--- a/src/main/ruby/lib/radp_vagrant/version.rb
+++ b/src/main/ruby/lib/radp_vagrant/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RadpVagrant
-  VERSION = 'v0.2.5'
+  VERSION = 'v0.2.6'
 end


### PR DESCRIPTION
Release prep for v0.2.6. When merged, create-version-tag will run automatically.