### PR TITLE
Release v0.2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## v0.2.8
 
+- docs: update changelog
+- chore(ci): update release-prep step 'update changelog'
+
+## v0.2.8
+
 ### feat
 
 - Add `vagrant-disksize` plugin support for disk resizing (e.g., Ubuntu boxes with 10GB default)

--- a/src/main/ruby/lib/radp_vagrant/version.rb
+++ b/src/main/ruby/lib/radp_vagrant/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RadpVagrant
-  VERSION = 'v0.2.7'
+  VERSION = 'v0.2.8'
 end


### PR DESCRIPTION
Release prep for v0.2.8. When merged, create-version-tag will run automatically.