### PR TITLE
Release v0.2.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,6 @@
 
 ## v0.2.13
 
-- docs: update changelog
-- fix: if hostname is empty, default to <guest-id>.<cluster-name>.<env>
-
-## v0.2.13
-
 ### feat
 
 - Add user triggers support with `user:` prefix


### PR DESCRIPTION
Release prep for v0.2.13. When merged, create-version-tag will run automatically.