### PR TITLE
Release v0.2.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,6 @@
 
 ## v0.2.14
 
-- feat(provision): Add `inline` support for builtin/user provision definitions
-- docs: update changelog
-
-## v0.2.14
-
 ### feat
 
 - Add user triggers support with `user:` prefix


### PR DESCRIPTION
Release prep for v0.2.14. When merged, create-version-tag will run automatically.