### PR TITLE
Release v0.2.32

### DIFF
--- a/packaging/copr/radp-vagrant-framework.spec
+++ b/packaging/copr/radp-vagrant-framework.spec
@@ -9,7 +9,7 @@
 #----------------------------------------------------------------------------------------------------------------------#
 
 Name:           radp-vagrant-framework
-Version:        0.2.31
+Version:        0.2.32
 Release:        1%{?dist}
 Summary:        YAML-driven framework for managing multi-machine Vagrant environments
 

--- a/packaging/obs/radp-vagrant-framework.spec
+++ b/packaging/obs/radp-vagrant-framework.spec
@@ -9,7 +9,7 @@
 #----------------------------------------------------------------------------------------------------------------------#
 
 Name:           radp-vagrant-framework
-Version:        0.2.31
+Version:        0.2.32
 Release:        1%{?dist}
 Summary:        YAML-driven framework for managing multi-machine Vagrant environments
 

--- a/src/main/ruby/lib/radp_vagrant/version.rb
+++ b/src/main/ruby/lib/radp_vagrant/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RadpVagrant
-  VERSION = 'v0.2.31'
+  VERSION = 'v0.2.32'
 end

--- a/src/main/shell/commands/version.sh
+++ b/src/main/shell/commands/version.sh
@@ -6,7 +6,7 @@
 # Version declaration - parsed by framework for --config and banner display
 # NOTE: This value should be kept in sync with src/main/ruby/lib/radp_vagrant/version.rb
 # Update this when releasing a new version
-declare -gr gr_app_version="v0.2.31"
+declare -gr gr_app_version="v0.2.32"
 
 cmd_version() {
   # Get version from Ruby (single source of truth)


### PR DESCRIPTION
Release prep for v0.2.32.

- Update VERSION in version.rb
- Update gr_app_version in version.sh
- Sync spec versions
- Regenerate completion scripts
- Add changelog entry (please review and edit)

When this PR is merged, create-version-tag will run automatically to validate and tag the release.
